### PR TITLE
  Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     RcppParallel (>= 5.0.1),
     Rdpack,
     rlang,
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.3.1),
     tibble,
     tidyr
@@ -39,8 +39,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 URL: https://github.com/fndemarqui/survstan,
     https://fndemarqui.github.io/survstan/

--- a/inst/stan/chunks/baselines.stan
+++ b/inst/stan/chunks/baselines.stan
@@ -3,7 +3,7 @@
 // Loglogistic distribution:
 
 
-real loglogistic_lpdf(real x, real alpha, real gamma){
+real loglogistic2_lpdf(real x, real alpha, real gamma){
   real aux = log1p(pow(x/gamma, alpha));
   real lpdf = log(alpha) - log(gamma) + lmultiply(alpha-1, x) -
   lmultiply(alpha-1, gamma) - 2*aux;
@@ -16,7 +16,7 @@ real loglogistic_lccdf(real x, real alpha, real gamma){
 }
 
 
-// real loglogistic_lpdf(real y, real mu, real sigma){
+// real loglogistic2_lpdf(real y, real mu, real sigma){
 //     return logistic_lpdf(log(y)|mu, sigma) - log(y);
 // }
 //

--- a/inst/stan/survreg.stan
+++ b/inst/stan/survreg.stan
@@ -1,7 +1,7 @@
 
 functions{
-#include /inst/stan/chunks/baselines.stan
-#include /inst/stan/chunks/loglikelihoods.stan
+#include /chunks/baselines.stan
+#include /chunks/loglikelihoods.stan
 }
 
 data{
@@ -57,11 +57,11 @@ transformed data{
 parameters{
   vector[p == 0 ? 0 : p] beta;
   vector[is_phi == 0 ? 0 : p] phi;
-  real<lower=0> alpha[is_alpha == 0 ? 0 : 1];
-  real<lower=0> gamma[is_gamma == 0 ? 0 : 1];
-  real<lower=0> lambda[is_lambda == 0 ? 0 : 1];
-  real mu[is_mu == 0 ? 0 : 1];
-  real<lower=0> sigma[is_sigma ==  0 ? 0 : 1];
+  array[is_alpha == 0 ? 0 : 1] real<lower=0> alpha;
+  array[is_gamma == 0 ? 0 : 1] real<lower=0> gamma;
+  array[is_lambda == 0 ? 0 : 1] real<lower=0> lambda;
+  array[is_mu == 0 ? 0 : 1] real mu;
+  array[is_sigma ==  0 ? 0 : 1] real<lower=0> sigma;
 }
 
 
@@ -108,7 +108,7 @@ model{
     }
   }else if(baseline == 4){
     for(i in 1:n){
-      lpdf[i] = loglogistic_lpdf(y[i]|alpha[1], gamma[1]);
+      lpdf[i] = loglogistic2_lpdf(y[i]|alpha[1], gamma[1]);
       lsurv[i] = loglogistic_lccdf(y[i]|alpha[1], gamma[1]);
     }
   }else if(baseline == 5){


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax
- `loglogistic_lpdf` renamed to `loglogistic2_lpdf` (clashes with existing Stan function)

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
