### PR TITLE
Update deprecated syntax and reserved keywords

### DIFF
--- a/R/aftreg.R
+++ b/R/aftreg.R
@@ -123,7 +123,7 @@ aftreg <- function(formula, data, baseline = "weibull", dist = NULL, init = 0, .
 
   baseline <- set_baseline(baseline)
 
-  stan_data <- list(time=y, event=event, X=X, n=n, p=p, offset = offset,
+  stan_data <- list(time=y, event=event, X=X, n=n, p=p, input_offset = offset,
                     baseline=baseline, survreg = 1, tau = tau, m = m, rho = rho/tau)
 
   fit <- rstan::optimizing(stanmodels$survreg, data = stan_data, hessian = TRUE, init = init, ...)

--- a/R/ahreg.R
+++ b/R/ahreg.R
@@ -123,7 +123,7 @@ ahreg <- function(formula, data, baseline = "weibull", dist = NULL, init = 0, ..
 
   baseline <- set_baseline(baseline)
 
-  stan_data <- list(time=y, event=event, X=X, n=n, p=p, offset = offset,
+  stan_data <- list(time=y, event=event, X=X, n=n, p=p, input_offset = offset,
                     baseline=baseline, survreg = 4, tau = tau, m = m, rho = rho/tau)
 
   fit <- rstan::optimizing(stanmodels$survreg, data = stan_data, hessian = TRUE, init = init, ...)

--- a/R/ehreg.R
+++ b/R/ehreg.R
@@ -129,7 +129,7 @@ ehreg <- function(formula, data, baseline = "weibull", dist = NULL, init = 0, ..
 
   baseline <- set_baseline(baseline)
 
-  stan_data <- list(time=y, event=event, X=X, n=n, p=p, offset = offset,
+  stan_data <- list(time=y, event=event, X=X, n=n, p=p, input_offset = offset,
                     baseline=baseline, survreg = 5, tau = tau, m=m, rho = rho/tau)
 
 

--- a/R/phreg.R
+++ b/R/phreg.R
@@ -113,7 +113,7 @@ phreg <- function(formula, data, baseline = "weibull", dist = NULL, init = 0, ..
 
   baseline <- set_baseline(baseline)
 
-  stan_data <- list(time=y, event=event, X=X, n=n, p=p, offset = offset,
+  stan_data <- list(time=y, event=event, X=X, n=n, p=p, input_offset = offset,
                     baseline=baseline, survreg = 2, tau = tau, m = m, rho = rho/tau)
 
   fit <- rstan::optimizing(stanmodels$survreg, data = stan_data, hessian = TRUE, init = init, ...)

--- a/R/poreg.R
+++ b/R/poreg.R
@@ -112,7 +112,7 @@ poreg <- function(formula, data, baseline = "weibull", dist = NULL, init = 0, ..
 
   baseline <- set_baseline(baseline)
 
-  stan_data <- list(time=y, event=event, X=X, n=n, p=p, offset = offset,
+  stan_data <- list(time=y, event=event, X=X, n=n, p=p, input_offset = offset,
                     baseline=baseline, survreg = 3, tau = tau, m = m, rho = rho/tau)
 
   fit <- rstan::optimizing(stanmodels$survreg, data = stan_data, hessian = TRUE, init = init, ...)

--- a/R/ypreg.R
+++ b/R/ypreg.R
@@ -119,7 +119,7 @@ ypreg <- function(formula, data, baseline = "weibull", dist = NULL, init = 0, ..
 
   baseline <- set_baseline(baseline)
 
-  stan_data <- list(time=y, event=event, X=X, n=n, p=p, offset = offset,
+  stan_data <- list(time=y, event=event, X=X, n=n, p=p, input_offset = offset,
                     baseline=baseline, survreg = 5, tau = tau, m=m, rho = rho/tau)
 
   fit <- rstan::optimizing(stanmodels$survreg, data = stan_data, hessian = TRUE, init = init, ...)

--- a/inst/stan/chunks/baselines.stan
+++ b/inst/stan/chunks/baselines.stan
@@ -190,10 +190,10 @@ vector bernstein_vlccdf(matrix G, vector xi){
 }
 
 
-int[] IDT(vector time, vector rho){
+array[] int IDT(vector time, vector rho){
   int n = num_elements(time);
   int j;
-  int idt[n];
+  array[n] int idt;
     for(i in 1:n){
       j = 0;
       while(time[i] > rho[j+1]){
@@ -205,7 +205,7 @@ int[] IDT(vector time, vector rho){
 }
 
 // version 1:
-vector piecewise_vlpdf(matrix ttt, int[] idt, vector xi){
+vector piecewise_vlpdf(matrix ttt, array[] int idt, vector xi){
   return log(xi[idt]) - ttt*xi;
 }
 

--- a/inst/stan/survreg.stan
+++ b/inst/stan/survreg.stan
@@ -11,7 +11,7 @@ data{
   vector[n] time;
   vector[n] event;
   matrix[p == 0 ? 0 : n, p] X;
-  vector[n] offset;
+  vector[n] input_offset;
   real tau;
   int baseline;
   int survreg;    // 1 - AFT; 2 - PH; 3 - PO; 4 - AH; 5 - YP; 6 - EH
@@ -32,7 +32,7 @@ transformed data{
   vector[p == 0 ? n : 0] zeros;
   matrix[baseline == 11 ? n : 0, m] g;
   matrix[baseline == 11 ? n : 0, m] G;
-  int idt[baseline == 12 ? n : 0];
+  array[baseline == 12 ? n : 0] int idt;
   matrix[baseline == 12 ? n : 0, m] ttt;
 
   int survreg146 = 0;
@@ -128,20 +128,20 @@ model{
   real Tau;
 
   if(p>0){
-    lp = X*beta + offset;
+    lp = X*beta + input_offset;
     if(survreg > 4){
       if(survreg == 5){
-        lp2 = X*phi + offset;
+        lp2 = X*phi + input_offset;
         K =  exp(X*(beta-phi));
       }else{
-        lp2 = X*phi + offset;
+        lp2 = X*phi + input_offset;
         K =  exp(lp+lp2);
       }
     }
   }else{
-    lp = zeros + offset;
+    lp = zeros + input_offset;
     if(survreg > 4){
-      lp2 = zeros + offset;
+      lp2 = zeros + input_offset;
       K = exp(zeros);
     }
   }


### PR DESCRIPTION
This PR updates some usages of deprecated array syntax and reserved keywords (`offset`) in your package's Stan model, otherwise it will fail to compile with future versions of RStan. Thanks!